### PR TITLE
To enable from fastai2_audio.all import *

### DIFF
--- a/fastai2_audio/all.py
+++ b/fastai2_audio/all.py
@@ -1,0 +1,2 @@
+from .core import *
+from .augment import *


### PR DESCRIPTION
This PR is to enable 
```python
from fastai2_audio.all import *
```
instead of
```python
from fastai2_audio.core import *
from fastai2_audio.augment import *
...
```