### PR TITLE
Fix numba.decorators issue

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ channels:
 dependencies:
 - fastprogress
 - jupyter
-- librosa
+- librosa>=0.8.0
 - matplotlib
 - pandas
 - pillow==6.1


### PR DESCRIPTION
Require librosa>=0.8.0 to fix import numba.decorators issue.